### PR TITLE
Support custom date format in gantt-tooltip directive.

### DIFF
--- a/assets/angular-gantt.js
+++ b/assets/angular-gantt.js
@@ -1795,8 +1795,8 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
             "{{ task.subject }}</br>" +
             "<small>" +
             "{{ task.isMilestone === true &&" +
-            " (task.from | date:'MMM d, HH:mm') ||" +
-            " (task.from | date:'MMM d, HH:mm') + ' - ' + (task.to | date:'MMM d, HH:mm') }}" +
+            " (task.from | date:dateFormat) ||" +
+            " (task.from | date:dateFormat) + ' - ' + (task.to | date:dateFormat) }}" +
             "</small>" +
             "</div>" +
             "</div>" +
@@ -1804,11 +1804,12 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
             "</div>",
         replace: true,
         transclude: true,
-        scope: { task: "=ngModel" },
+        scope: { task: "=ngModel", dateFormat: "=dateFormat" },
         controller: ['$scope', '$element', function ($scope, $element) {
             var bodyElement = angular.element($document[0].body);
             $scope.visible = false;
             $scope.css = {};
+            $scope.dateFormat = $scope.dateFormat || 'MMM d, HH:mm';
 
             $scope.mouseEnter = function (e) {
                 if (!$scope.task.isMoving) {

--- a/template/gantt.tmpl.html
+++ b/template/gantt.tmpl.html
@@ -87,7 +87,7 @@
                          ng-click="raiseDOMTaskClickedEvent($event, task)"
                          ng-repeat="task in row.tasks | ganttTaskLimit:scroll_start:scroll_width track by task.id"
                          gantt-task-moveable>
-                        <gantt-tooltip ng-model="task">
+                        <gantt-tooltip ng-model="task" date-format="'MMM d, HH:mm'">
                             <div class="gantt-task-content"><span>{{ (task.isMilestone === true && '&nbsp;' || task.subject) }}</span></div>
                         </gantt-tooltip>
                     </div>


### PR DESCRIPTION
#### Motivation

I am using the angular-gantt module to display availability of physical things. It's like a reservation system. (The Angular-Gantt module is super awesome. Nice job!)

My things are reserved by the day, not by the hour or minute. When I hover on one of my item's reservations (a row's "task"), I see the date and time. I want just the date.
#### Solution

This date is defined in a "ganttTooltip" directive. Nice design! Even better, this date is passed through a date formatting filter. All we have to do is change this to a variable and set the variable from somewhere. Where do we pass in the custom date format?

I see two places to pass a custom date format:
1. Create a new ganttTooltip directive attribute, called  "dateFormat"
2. A property on the object specified by the `ngModel` attribute
3. (Other?)

Which is better? If I get a quick response, I can update my pull request to use a different solution.

This Pull Request implements option 1. I customized my gantt template to include a `date-format` attribute on the `gantt-tooltip` element.
