### PR TITLE
Add priority option for tasks.

### DIFF
--- a/assets/angular-gantt.js
+++ b/assets/angular-gantt.js
@@ -1032,7 +1032,7 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
                 task = self.tasksMap[taskData.id];
                 task.copy(taskData);
             } else {
-                task = new Task(taskData.id, self, taskData.subject, taskData.color, taskData.from, taskData.to, taskData.data);
+                task = new Task(taskData.id, self, taskData.subject, taskData.color, taskData.priority, taskData.from, taskData.to, taskData.data);
                 self.tasksMap[taskData.id] = task;
                 self.tasks.push(task);
             }
@@ -1121,7 +1121,7 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
 
     return Row;
 }]);;gantt.factory('Task', ['dateFunctions', function (df) {
-    var Task = function(id, row, subject, color, from, to, data) {
+    var Task = function(id, row, subject, color, priority, from, to, data) {
         var self = this;
 
         self.id = id;
@@ -1129,6 +1129,7 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
         self.row = row;
         self.subject = subject;
         self.color = color;
+        self.priority = priority;
         self.from = df.clone(from);
         self.to = df.clone(to);
         self.data = data;
@@ -1193,6 +1194,7 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
         self.copy = function(task) {
             self.subject = task.subject;
             self.color = task.color;
+            self.priority = task.priority;
             self.from = df.clone(task.from);
             self.to = df.clone(task.to);
             self.data = task.data;
@@ -1200,7 +1202,7 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
         };
 
         self.clone = function() {
-            return new Task(self.id, self.row, self.subject, self.color, self.from, self.to, self.data);
+            return new Task(self.id, self.row, self.subject, self.color, self.priority, self.from, self.to, self.data);
         };
     };
 

--- a/template/gantt.tmpl.html
+++ b/template/gantt.tmpl.html
@@ -83,7 +83,7 @@
                      ng-repeat="row in gantt.rows track by row.id">
                     <!--a task will override the row event -->
                     <div ng-class="(task.isMilestone === true && 'gantt-task-milestone' || 'gantt-task')"
-                         ng-style="{'left': ((task.isMilestone === true || task.width === 0) && (task.left-0.3) || task.left)+'em', 'width': task.width +'em', 'z-index': (task.isMoving === true && 1 || ''), 'background-color': task.color}"
+                         ng-style="{'left': ((task.isMilestone === true || task.width === 0) && (task.left-0.3) || task.left)+'em', 'width': task.width +'em', 'z-index': (task.isMoving === true && 1  || task.priority || ''), 'background-color': task.color}"
                          ng-click="raiseDOMTaskClickedEvent($event, task)"
                          ng-repeat="task in row.tasks | ganttTaskLimit:scroll_start:scroll_width track by task.id"
                          gantt-task-moveable>


### PR DESCRIPTION
In my situation, I have some tasks which are quite long. This is an edge-case, real or not. In this case, a task may occur in the middle of another task on the same row.

I would like to set a priority level for each task, so that we can intelligently decide if the shorter task should be hidden behind the longer task.

Same as my other pull-request; I don't expect this to be accepted as-is. I'd rather not re-write this to fit your standards, so I'd be happy if this serves only as an idea or as a reference.

Thanks for the great module!
