### PR TITLE
Move row z-index to top on hover too ensure its tooltip is above all.

### DIFF
--- a/assets/gantt.css
+++ b/assets/gantt.css
@@ -114,6 +114,12 @@
     position: relative;
 }
 
+/* Move row to top when hovering to ensure its tooltips
+     appear above other tasks which may have higher z-index.  */
+.gantt-row:hover {
+    z-index: 999;
+}
+
 .gantt-row-height {
     height: 2em;
 }


### PR DESCRIPTION
Since we added priorities to tasks, the tooltip of a lower-priority task will appear underneath a higher-priority task. This patch fixes that by boosting the z-index of the task's row. If we boost the z-index of only the task, it causes the hovered task to jump above other higher-priority tasks in that row. I didn't want that.

I did some looking, and this appears to be a pretty good solution. Is it the best? That's hard to say. I welcome more ideas.

Another solution I considered was adding an `ng-mouseover` attribute to each task. Then, we can register a function with that event which will raise the z-index of only the currently selected task. We could implement this in a similar way to the `onTaskClicked` attribute of the Gantt directive to allow a user to do do additional stuff, such as changing its background color or something.
