### PR TITLE
Add date and column to task-click event object.

### DIFF
--- a/src/gantt.directive.js
+++ b/src/gantt.directive.js
@@ -314,7 +314,17 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
             };
 
             $scope.raiseTaskClickedEvent = function(evt, task) {
-                $scope.onTaskClicked({ event: { evt: evt, task: task, userTriggered: true } });
+                var x = mouseOffset.getOffset(evt).x,
+                    xInEm = x / $scope.getPxToEmFactor(),
+                    clickedColumn = $scope.gantt.getColumnByPosition(xInEm + task.left),
+                    date = $scope.gantt.getDateByPosition(xInEm + task.left);
+                $scope.onTaskClicked({ event: {
+                    evt: evt,
+                    task: task,
+                    column: clickedColumn,
+                    date: date,
+                    userTriggered: true
+                } });
             };
 
             $scope.raiseTaskDblClickedEvent = function(evt, task) {


### PR DESCRIPTION
When a user clicks on a task, I want to see exactly which date was clicked. To do that, I added a "date" property to the event object. I also added the "Column" object which was clicked just because I could, but I don't know if that's such a good choice.

What do you think?
