### PR TITLE
Change gantt component-finding to use classname.

### DIFF
--- a/src/gantt.directive.js
+++ b/src/gantt.directive.js
@@ -90,8 +90,8 @@ gantt.directive('gantt', ['Gantt', 'dateFunctions', 'mouseOffset', 'debounce', '
             // Gantt logic
             $scope.gantt = new Gantt($scope.viewScale, $scope.columnWidth, $scope.columnSubScale, $scope.firstDayOfWeek, $scope.weekendDays, $scope.showWeekends, $scope.workHours, $scope.showNonWorkHours);
             $scope.gantt.expandDefaultDateRange($scope.fromDate, $scope.toDate);
-            $scope.ganttHeader = $element.children()[1];
-            $scope.ganttScroll = angular.element($element.children()[2]);
+            $scope.ganttHeader = $element.find('.gantt-head');
+            $scope.ganttScroll = angular.element($element.find('.gantt-scrollable'));
 
             $scope.$watch("sortMode", function (newValue, oldValue) {
                 if (!angular.equals(newValue, oldValue)) {


### PR DESCRIPTION
I put a page on my server to load with the `template-url` attribute of the `gantt` directive. I wanted some custom styles to be used by all my stuff, so I did this:

```
<div class="gantt">
    <style type="text/css">
        /* my styles */
    </style>
    <div class="gantt-labels" ... >
        ...
    </div>
    <div class="gantt-head" ... >
        ...
    </div>
    <div class="gantt-scrollable" ... >
        ...
    </div>
</div>
```

Some stuff in my gantt broke when I did this, such as the `onScroll` event. I checked it out, and it appears that it finds the `gantt-scrollable` element by just counting children. Adding my `style` element made the count wrong, and the grid broke.

What's your opinion about using the `$element.find` instance method for this?
