### PR TITLE
Add CSS to bower.json main property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,10 @@
     "Schweigi"
   ],
   "description": "A Gantt chart directive for Angular.js without any other dependencies.",
-  "main": "./assets/angular-gantt.js",
+  "main": [
+    "./assets/angular-gantt.js",
+    "./assets/gantt.css"
+  ],
   "keywords": [
     "gantt",
     "chart",


### PR DESCRIPTION
In order to work out of the box with [wiredep](https://github.com/taptapship/wiredep) and [yeoman angular generator](https://github.com/yeoman/generator-angular), CSS should be present in the main property.
