### PR TITLE
Update view when moving/resizing a task.

### DIFF
--- a/src/ui/task/task.directive.js
+++ b/src/ui/task/task.directive.js
@@ -212,9 +212,11 @@ gantt.directive('ganttTask', ['$window', '$document', '$timeout', 'smartEvent', 
 
                 // Add move event handlers
                 var taskMoveHandler = debounce(function(e) {
+                  $timeout(function() {
                     var mousePos = mouseOffset.getOffsetForElement(ganttBodyElement[0], e);
                     clearScrollInterval();
                     handleMove(mode, mousePos);
+                  });
                 }, 5);
                 smartEvent($scope, windowElement, 'mousemove', taskMoveHandler).bind();
 


### PR DESCRIPTION
When moving or resizing a task, the view is not updated with model changes while moving the mouse.

This fix add a timeout call to synchronize view and model when it changes.
