### PR TITLE
$scope.row was not reliable after clearData()

### DIFF
--- a/src/ui/task/task.directive.js
+++ b/src/ui/task/task.directive.js
@@ -19,7 +19,7 @@ gantt.directive('ganttTask', ['$window', '$document', '$timeout', '$filter', 'sm
             var scrollTriggerDistance = 5;
 
             var windowElement = angular.element($window);
-            var ganttRowElement = $scope.row.$element;
+            var ganttRowElement = angular.element($element[0].parentElement);
             var ganttBodyElement = $scope.template.body.$element;
             var ganttScrollElement = $scope.template.scrollable.$element;
 


### PR DESCRIPTION
Some rows were null or undefined after using a clearData() and then adding rows and tasks back in. 

It was causing the dragging of task to fail during getRowByY because ganttRowElement was undefined. 

This was my fix.
