### PR TITLE
Attribute for showing/hiding column of labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ review those projects documentations.
   Width of label section on the left side of the Gantt. This property support two way binding. Therefore if the user
   resizes the label section any assigned scope variable will be updated too.
 
+- **show-labels-column** (default: `true`)
+
+  Whether the column with labels is to be shown or not. This attribute support two way binding, hence the visibility
+  of the column may be toggled.
+
 - **load-data**
 
   Function (`fn`) called to load more data to the Gantt.

--- a/src/gantt.directive.js
+++ b/src/gantt.directive.js
@@ -85,6 +85,7 @@ gantt.directive('gantt', ['Gantt', 'moment', 'mouseOffset', 'debounce', 'keepScr
             taskOutOfRange: '=?', // Set this to expand or truncate to define the behavior of tasks going out of visible range.
             maxHeight: '=?', // Define the maximum height of the Gantt in PX. > 0 to activate max height behaviour.
             labelsWidth: '=?', // Define the width of the labels section. Changes when the user is resizing the labels width
+            showLabelsColumn: '=?', // Whether to show column with labels or not. Default (true)
             showTooltips: '=?', // True when tooltips shall be enabled. Default (true)
             headerShowMonth: '=?',
             headerShowWeek: '=?',
@@ -164,6 +165,9 @@ gantt.directive('gantt', ['Gantt', 'moment', 'mouseOffset', 'debounce', 'keepScr
             }
             if ($scope.labelsWidth === undefined) {
                 $scope.labelsWidth = 0;
+            }
+            if ($scope.showLabelsColumn === undefined) {
+                $scope.showLabelsColumn = true;
             }
             if ($scope.showTooltips === undefined) {
                 $scope.showTooltips = true;

--- a/src/template/default.gantt.tmpl.html
+++ b/src/template/default.gantt.tmpl.html
@@ -112,7 +112,7 @@
 
     <!-- Labels template -->
     <script type="text/ng-template" id="template/default.labels.tmpl.html">
-        <div ng-transclude class="gantt-labels"
+        <div ng-transclude ng-if="showLabelsColumn" class="gantt-labels"
              ng-style="(labelsWidth > 0 && {'width': labelsWidth+'px'} || {})"
              gantt-labels-resize="allowLabelsResizing" gantt-labels-resize-width="labelsWidth" gantt-labels-resize-min-width="50"></div>
     </script>


### PR DESCRIPTION
feat(gantt-label):add attribute for showing or hiding column of labels

In some circumstances, for example where the screen estate is scarce, it
is useful to be able to hide the column of labels to get a better
overview. This is a missing feature.
