### PR TITLE
Priority should affect task contents, not container

### DIFF
--- a/src/core/logic/task/task.factory.js
+++ b/src/core/logic/task/task.factory.js
@@ -96,7 +96,10 @@
                     this.$element.css({'left': this.left + 'px', 'width': this.width + 'px', 'display': ''});
 
                     if (this.model.priority > 0) {
-                        this.$element.css('z-index', this.model.priority);
+                        var priority = this.model.priority;
+                        this.$element.children().each(function(i, element) {
+                            angular.element(element).css('z-index', priority);
+                        });
                     }
 
                     this.$element.toggleClass('gantt-task-milestone', this.isMilestone());


### PR DESCRIPTION
If a task in Row 1 has z-index 50, and a task in Row 2 has z-index 25, the tooltip for Row 2's task appears underneath Row 1's task bar. Removing the z-index from the task container fixes this.

I don't have a demo for this problem, nor did I format the commit message as asked. I'll submit the patch now and fix the commit message later, if I can.