### PR TITLE
(package.json) fix .main for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chart",
     "angularjs"
   ],
-  "main": "/assets/angular-gantt.js",
+  "main": "assets/angular-gantt.js",
   "directories.doc": "docs",
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
When installing via __npm__ and trying to bundle with __browserify__ I get the following error:

```
Error: Cannot find module 'angular-gantt' from '/home/rory/Repos/__sandbox__'
    at /home/rory/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:46:17
    at process (/home/rory/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:173:43)
    at ondir (/home/rory/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:188:17)
    at load (/home/rory/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
    at onex (/home/rory/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
    at /home/rory/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:78:15)
```

This change to `package.json` fixes the issue and __angular gantt__ gets successfully bundled.