### PR TITLE
Document the gotcha when trying to remove children from the data

### DIFF
--- a/plugins/tree/index.html
+++ b/plugins/tree/index.html
@@ -256,6 +256,7 @@ can be used to define the hierarchy.</p>
 ]
 </code></pre>
 <p>Take care to define a non-recursive hierarchy model, and check that a row is attached to a maximum of one parent.</p>
+<p>When removing a child from the data, be sure to break the link between parent and child. For instance, set `myrow.parent = '';` before removing the row from the data.</p>
 <h2 id="attributes">Attributes</h2>
 <ul>
 <li>


### PR DESCRIPTION
When using the tree plugin the default sorting function (`sortRowsFunction`) will rebuild the children array whilst retaining a reference to the children from before the child row was removed. This documents the issue #430 as it currently stands.