### PR TITLE
fix: refresh tree hierarchy upon child removal

### DIFF
--- a/src/plugins/tree/tree.controller.js
+++ b/src/plugins/tree/tree.controller.js
@@ -108,6 +108,10 @@
         $scope.gantt.api.rows.addRowSorter(sortRowsFunction);
         $scope.gantt.api.rows.addRowFilter(filterRowsFunction);
 
+        $scope.gantt.api.rows.on.remove($scope, function () {
+            refresh();
+        });
+
         $scope.$on('$destroy', function() {
             $scope.gantt.api.rows.removeRowSorter(sortRowsFunction);
             $scope.gantt.api.rows.removeRowFilter(filterRowsFunction);


### PR DESCRIPTION
When removing a child from a tree row, make sure the hierarchy is rebuilt so the UI can update itself. Credit to @stimmins for this patch.

This should fix #430