### PR TITLE
Bower json main files fixed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,10 +8,10 @@
   ],
   "description": "Gantt chart component for AngularJS",
   "main": [
-    "./assets/angular-gantt.js",
-    "./assets/angular-gantt.css",
-    "./assets/angular-gantt-plugins.js",
-    "./assets/angular-gantt-plugins.css"
+    "./dist/angular-gantt.min.js",
+    "./dist/angular-gantt.min.css",
+    "./dist/angular-gantt-plugins.min.js",
+    "./dist/angular-gantt-plugins.min.css"
   ],
   "keywords": [
     "gantt",


### PR DESCRIPTION
Main files paths in bower.json changed to the minified distribution versions, so that wiredep can easily inject them