### PR TITLE
fix(columns): change selected column

### DIFF
--- a/src/core/logic/column/columnsManager.factory.js
+++ b/src/core/logic/column/columnsManager.factory.js
@@ -237,6 +237,11 @@
             var columns = bs.get(extendedColumns, date, function(c) {
                 return c.date;
             }, true);
+            
+            if(columns.length === 2 && columns[1] !== undefined && columns[1].date <= date){
+                return columns[1];
+            }
+            
             return columns[0] !== undefined ? columns[0] : columns[1];
         };
 


### PR DESCRIPTION
This will fix the problem where the bar gets added an increment on the beginning if it starts exactly where the gantt chart starts but there is another task that starts before the beginning of the gantt chart.