### PR TITLE
Added headers-scales attribute.

### DIFF
--- a/docs/configuration/attributes.md
+++ b/docs/configuration/attributes.md
@@ -185,6 +185,20 @@
           }
         };
 
+- ### headers-scales
+
+    Associative object of headers view scales, indicating which scale each header should use. Key is the header, and value is the view scale.
+
+    Scale can be any [momentJS#add()](http://momentjs.com/docs/#/manipulating/add/) supported unit.
+
+        <div gantt headers="['dayLetter', 'day']" headers-formats="{dayLetter: 'dd'}" headers-scales="{dayLetter: 'day'}"></div>
+
+    <!-- -->
+
+        $scope.headersScales = {
+          dayLetter: 'day'
+        };
+
 - ### time-frames, date-frames
 
     TimeFrames and DateFrames are used to configure global calendar in the gantt.

--- a/src/core/gantt.directive.js
+++ b/src/core/gantt.directive.js
@@ -42,6 +42,7 @@
                 sideWidth: '=?',
                 headers: '=?',
                 headersFormats: '=?',
+                headersScales: '=?',
                 timeFrames: '=?',
                 dateFrames: '=?',
                 timeFramesWorkingMode: '=?',

--- a/src/core/logic/column/columnsManager.factory.js
+++ b/src/core/logic/column/columnsManager.factory.js
@@ -425,6 +425,21 @@
             return format;
         };
 
+        ColumnsManager.prototype.getHeaderScale = function(header) {
+            var scale;
+            var headersScales = this.gantt.options.value('headersScales');
+            if (headersScales !== undefined) {
+                scale = headersScales[header];
+            }
+            if (scale === undefined) {
+                scale = header;
+            }
+            if (['second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year'].indexOf(scale) === -1) {
+                scale = 'day';
+            }
+            return scale;
+        };
+
         ColumnsManager.prototype.getDateRange = function(visibleOnly) {
             var firstColumn, lastColumn;
 

--- a/src/core/logic/column/headersGenerator.service.js
+++ b/src/core/logic/column/headersGenerator.service.js
@@ -1,9 +1,11 @@
 (function(){
     'use strict';
     angular.module('gantt').service('GanttHeadersGenerator', ['GanttColumnHeader', 'moment', function(ColumnHeader, moment) {
-        var generateHeader = function(columnsManager, viewScale) {
+        var generateHeader = function(columnsManager, value) {
             var generatedHeaders = [];
             var header;
+
+            var viewScale = columnsManager.getHeaderScale(value);
 
             var viewScaleValue;
             var viewScaleUnit;
@@ -37,7 +39,7 @@
                 var width = left - currentPosition;
 
                 if (width > 0) {
-                    var labelFormat = columnsManager.getHeaderFormat(viewScaleUnit);
+                    var labelFormat = columnsManager.getHeaderFormat(value);
 
                     header = new ColumnHeader(currentDate, endDate, viewScaleUnit, currentPosition, width, labelFormat);
                     generatedHeaders.push(header);


### PR DESCRIPTION
I ran into a case where I needed to add a header row that shows `Su Mo Tu We Th Fr Sa` above the `day` header showing `1 2 3 4 5 6 7`.

This is not currently possible because the GanttHeadersGenerator service expects each header in the `headers` attribute to equal a scale unit (days, hours, etc).

I propose adding a new attribute called 'headers-scales', which is an associative object containing a map from the value in `headers` to a corresponding view scale unit. If this attribute is not passed, or there is not an explicit mapping, it will assume that the header value _is_ the scale unit. Finally, if the scale unit is not valid, it will fall back to `day`.