### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ You can find released version on CDNs.
 
 [jsDelivr](http://www.jsdelivr.com/)
 
-    //cdn.jsdelivr.net/angular.gantt/latest/angular-gantt.min.js
-    //cdn.jsdelivr.net/angular.gantt/latest/angular-gantt.min.css
+    //cdn.jsdelivr.net/npm/angular-gantt@latest/dist/angular-gantt.min.js
+    //cdn.jsdelivr.net/npm/angular-gantt@latest/dist/angular-gantt.min.css
 
 [CDNjs](http://www.cdnjs.com/) (Replace `<version>` with latest github tag)
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.
I also noticed some old links at https://www.angular-gantt.com/get-started/, the correct links are: 
//cdn.jsdelivr.net/npm/angular-gantt@latest/dist/angular-gantt.min.css
//cdn.jsdelivr.net/npm/angular-gantt@latest/dist/angular-gantt.min.css
//cdn.jsdelivr.net/npm/angular-gantt@latest/dist/angular-gantt.min.js

You can find links for all files at https://www.jsdelivr.com/package/npm/angular-gantt.

Feel free to ping me if you have any questions regarding this change.