### PR TITLE
Fix TypeError during task move

### DIFF
--- a/src/plugins/movable/movable.directive.ts
+++ b/src/plugins/movable/movable.directive.ts
@@ -174,7 +174,7 @@ export default function (ganttMouseButton: GanttMouseButton,
 
                 // tslint:disable:one-variable-per-declaration
                 for (let i = 0, l = rows.length; i < l; i++) {
-                  if (targetRowElement === rows[i].$element[0]) {
+                  if (rows[i].$element && targetRowElement === rows[i].$element[0]) {
                     targetRow = rows[i]
                     break
                   }


### PR DESCRIPTION
This error comes out while moving a task to a different row when has subtasks and the rows are collapsed.